### PR TITLE
update dockerfile and run file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # cloudacademydevops/simplewebsvr
-FROM openshift/base-centos7
+FROM quay.io/sclorg/s2i-base-c10s
 
 # Put the maintainer name in the image metadata
 LABEL maintainer="Jeremy Cook <jeremy.cook@cloudacademy.com>"

--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-echo " -----> Start Python SimpleHTTPServer web server port 8080"
+echo " -----> Start Python3 http.server web server on default port 8080"
 
-exec python -m SimpleHTTPServer 8080
+exec python3 -m http.server 8080


### PR DESCRIPTION
CentOS 7 no longer supported.
CentOS Stream 10 includes Python 3, in which the SimpleHTTPServer module has been removed.